### PR TITLE
[Feature] Rating prompt with min time

### DIFF
--- a/Sources/RateKit/RateKit.swift
+++ b/Sources/RateKit/RateKit.swift
@@ -18,8 +18,7 @@ public struct RateKit {
     /// - Returns: App version + build
     @discardableResult
     public static func displayRatingsIfRequired(launchesBeforeRating: Int = 5) -> String? {
-        incrementLaunches()
-        let launches = launchCount()
+        let launches = incrementLaunches()
 
         if launches >= launchesBeforeRating {
             SKStoreReviewController.requestReview()
@@ -32,15 +31,12 @@ public struct RateKit {
 // MARK: - Helper methods
 
 extension RateKit {
-    private static func launchCount() -> Int {
+    private static func incrementLaunches() -> Int {
         checkAppCurrentVersion()
-        return userDefaults.integer(forKey: kAppLaunches)
-    }
-
-    private static func incrementLaunches() {
         var launches = userDefaults.integer(forKey: kAppLaunches)
         launches += 1
         set(value: launches, forKey: kAppLaunches)
+        return launches
     }
 
     private static func checkAppCurrentVersion() {

--- a/Sources/RateKit/RateKit.swift
+++ b/Sources/RateKit/RateKit.swift
@@ -10,55 +10,75 @@ import SystemConfiguration
 
 public struct RateKit {
     private static var userDefaults = UserDefaults()
-    private static let kAppCurrentVersion      = "Version"
-    private static let kAppLaunches            = "Launches"
+    private static let kAppCurrentVersionKey   = "AppCurrentVersion"
+    private static let kAppLaunchesKey         = "AppLaunches"
+    private static let kLastReviewRequestedKey = "LastReviewRequested"
 
-    /// Request for review after a define number of lauches
-    /// - Parameter launchesBeforeRating: Lauches before prompt review message (default value is 5 times)
-    /// - Returns: App version + build
+    /// Requests a review prompt if all conditions are met.
+    /// - Parameters:
+    ///   - launchesBeforeAskingForReview: The number of launches before requesting a review. Default is 5.
+    ///   - minTimeBetweenRequestsInDays: The minimum time in days between review requests. Default is 30 days.
+    /// - Returns: The current app version.
     @discardableResult
-    public static func displayRatingsIfRequired(launchesBeforeRating: Int = 5) -> String? {
-        let launches = incrementLaunches()
-
-        if launches >= launchesBeforeRating {
+    public static func displayRatingsIfRequired(launchesBeforeAskingForReview: Int = 5, minTimeBetweenRequestsInDays: Int = 30) -> String? {
+        if canAskForRating(minLaunches: launchesBeforeAskingForReview, delayInDays: minTimeBetweenRequestsInDays) {
             SKStoreReviewController.requestReview()
-            print("Review has requested in \(launches) lauches")
+            setLastReviewRequested()
         }
-        return userDefaults.string(forKey: kAppCurrentVersion)
+        return userDefaults.string(forKey: kAppCurrentVersionKey)
     }
 }
 
 // MARK: - Helper methods
 
 extension RateKit {
-    private static func incrementLaunches() -> Int {
+    private static func canAskForRating(minLaunches: Int, delayInDays: Int) -> Bool {
         checkAppCurrentVersion()
-        var launches = userDefaults.integer(forKey: kAppLaunches)
+        let launches = incrementLaunches()
+        let lastReviewRequested = checkLastReviewRequested()
+        let minTimeInterval = TimeInterval(delayInDays * 24 * 60 * 60)
+        
+        debugPrint("Number of launches \(launches) since \(Date().timeIntervalSince(lastReviewRequested))")
+        return launches >= minLaunches && Date().timeIntervalSince(lastReviewRequested) > minTimeInterval
+    }
+    
+    private static func incrementLaunches() -> Int {
+        var launches = userDefaults.integer(forKey: kAppLaunchesKey)
         launches += 1
-        set(value: launches, forKey: kAppLaunches)
+        set(value: launches, forKey: kAppLaunchesKey)
         return launches
     }
 
+    private static func checkLastReviewRequested() -> Date {
+        let time = userDefaults.double(forKey: kLastReviewRequestedKey)
+        return Date(timeIntervalSince1970: time)
+    }
+    
+    private static func setLastReviewRequested() {
+        set(value: Date(), forKey: kLastReviewRequestedKey)
+    }
+    
     private static func checkAppCurrentVersion() {
         let infoDictionaryKey = kCFBundleVersionKey as String
 
         guard let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
               let appBuild = Bundle.main.object(forInfoDictionaryKey: infoDictionaryKey) as? String else {
-            print("Expected to find a bundle version in the info dictionary")
+            debugPrint("Expected to find a bundle version in the info dictionary")
             return
         }
 
         let appCurrentVersion = "\(appVersion).\(appBuild)"
 
-        // Save if new version and reset launches
-        if appCurrentVersion != userDefaults.string(forKey: kAppCurrentVersion) {
-            set(value: appCurrentVersion, forKey: kAppCurrentVersion)
+        // Save if new version and reset
+        if appCurrentVersion != userDefaults.string(forKey: kAppCurrentVersionKey) {
+            set(value: appCurrentVersion, forKey: kAppCurrentVersionKey)
             reset()
         }
     }
 
     private static func reset() {
-        set(value: 0, forKey: kAppLaunches)
+        set(value: 0, forKey: kAppLaunchesKey)
+        set(value: nil, forKey: kLastReviewRequestedKey)
     }
 
     private static func set(value: Any?, forKey key: String) {


### PR DESCRIPTION
### Description
This pull request introduces a new parameter, `minTimeBetweenRequestsInDays`, to the `displayRatingsIfRequired` method in the `RateKit` struct. The purpose of this addition is to prevent multiple review requests from being triggered rapidly after the specified number of `launchesBeforeAskingForReview` has been reached.

### Context
Previously, our `RateKit` struct only considered the number of app launches (`launchesBeforeAskingForReview`) before requesting a review. However, in some cases, users may launch the app frequently in a short amount of time, leading to multiple requests to Apple. To address this, we've added the `minTimeBetweenRequestsInDays` parameter, which ensures that a new review request will only be made if the specified number of days have passed since the last review request.

### Changes Made
- Added a new parameter, `minTimeBetweenRequestsInDays`, to the `displayRatingsIfRequired` method in the `RateKit` struct.
- Modified the logic in the `displayRatingsIfRequired` method to consider both the number of launches and the time interval between review requests.
- Extract the `displayRatingsIfRequired` to a private method `canAskForRating` to improve readability.

### Example Usage
```swift
let launchesBeforeAskingForReview = 5
let minTimeBetweenRequestsInDays = 30

RateKit.displayRatingsIfRequired(
    launchesBeforeAskingForReview: launchesBeforeAskingForReview,
    minTimeBetweenRequestsInDays: minTimeBetweenRequestsInDays
)